### PR TITLE
Flexible mints

### DIFF
--- a/DaoBuilder/dcntTokenDeploy.ts
+++ b/DaoBuilder/dcntTokenDeploy.ts
@@ -2,7 +2,7 @@ import { DecentDAOConfig } from "./types";
 import { BigNumber } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { ethers } from "hardhat";
-import { DCNTToken, LockRelease, UnlimitedMint__factory } from "../typechain";
+import { DCNTToken, LockRelease, NoMint__factory } from "../typechain";
 
 export const deployDCNTAndLockRelease = async (
   deployer: SignerWithAddress,
@@ -20,7 +20,7 @@ export const deployDCNTAndLockRelease = async (
     ethers.utils.parseEther(decentDAOConfig.initialSupply),
     await deployer.getAddress(),
     (
-      await new UnlimitedMint__factory(deployer).deploy()
+      await new NoMint__factory(deployer).deploy()
     ).address
   );
   await dcntTokenContract.deployed();

--- a/DaoBuilder/dcntTokenDeploy.ts
+++ b/DaoBuilder/dcntTokenDeploy.ts
@@ -2,7 +2,7 @@ import { DecentDAOConfig } from "./types";
 import { BigNumber } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { ethers } from "hardhat";
-import { DCNTToken, LockRelease } from "../typechain";
+import { DCNTToken, LockRelease, UnlimitedMint__factory } from "../typechain";
 
 export const deployDCNTAndLockRelease = async (
   deployer: SignerWithAddress,
@@ -18,7 +18,10 @@ export const deployDCNTAndLockRelease = async (
   const dcntTokenFactory = await ethers.getContractFactory("DCNTToken");
   const dcntTokenContract = await dcntTokenFactory.deploy(
     ethers.utils.parseEther(decentDAOConfig.initialSupply),
-    await deployer.getAddress()
+    await deployer.getAddress(),
+    (
+      await new UnlimitedMint__factory(deployer).deploy()
+    ).address
   );
   await dcntTokenContract.deployed();
 

--- a/contracts/DCNTToken.sol
+++ b/contracts/DCNTToken.sol
@@ -8,35 +8,17 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @notice the dcnt token
 contract DCNTToken is ERC20Votes, Ownable {
-    uint128 public nextMint; // Timestamp
-    uint32 public constant MINIMUM_MINT_INTERVAL = 365 days;
-    uint8 public constant MINT_CAP_BPS = 200; // 2%
-
-    error MintExceedsMaximum();
-    error MintTooSoon();
-
     /// @param _supply amount of tokens to mint at Token Generation Event
     constructor(uint256 _supply, address _owner) ERC20("Decent", "DCNT") ERC20Permit("Decent") {
         _mint(msg.sender, _supply);
-        nextMint = uint128(block.timestamp + MINIMUM_MINT_INTERVAL);
         _transferOwnership(_owner);
     }
 
-    /// @notice mint can be called at most once every 365 days,
-    ///  and with an amount no more than 2% of the current supply
+    /// @notice public mint function to be used for minting new tokens
     /// @param dest address to assign newly minted tokens to
     /// @param amount amount of tokens to mint
     /// @dev only the `owner` is authorized to mint more tokens
     function mint(address dest, uint256 amount) external onlyOwner {
-        if (amount > (totalSupply() * MINT_CAP_BPS) / 10000) {
-            revert MintExceedsMaximum();
-        }
-
-        if (block.timestamp < nextMint) {
-            revert MintTooSoon();
-        }
-
-        nextMint = uint128(block.timestamp + MINIMUM_MINT_INTERVAL);
         _mint(dest, amount);
     }
 

--- a/contracts/DCNTToken.sol
+++ b/contracts/DCNTToken.sol
@@ -11,10 +11,12 @@ import { IDCNTMintAuthorization } from "./mint/IDCNTMintAuthorization.sol";
 contract DCNTToken is ERC20Votes, AccessControl {
     IDCNTMintAuthorization public mintAuthorization;
     bytes32 public constant MINT_ROLE = keccak256("MINT_ROLE");
+    bytes32 public constant UPDATE_MINT_AUTHORIZATION_ROLE = keccak256("UPDATE_MINT_AUTHORIZATION_ROLE");
     error MintAuthorization();
 
     constructor(uint256 _supply, address _owner, IDCNTMintAuthorization _mintAuthorization) ERC20("Decent", "DCNT") ERC20Permit("Decent") {
         _grantRole(MINT_ROLE, _owner);
+        _grantRole(UPDATE_MINT_AUTHORIZATION_ROLE, _owner);
         _mint(msg.sender, _supply);
         mintAuthorization = _mintAuthorization;
     }
@@ -33,5 +35,12 @@ contract DCNTToken is ERC20Votes, AccessControl {
     /// @notice holders can burn their own tokens
     function burn(uint256 amount) external {
         _burn(msg.sender, amount);
+    }
+
+    /// @notice public function to update contract used for mint authorization
+    /// @param newMintAuthorization address to use for the new mint authorization contract
+    /// @dev only accounts with `UPDATE_MINT_AUTHORIZATION_ROLE` (the DAO) are authorized to update mint authorization
+    function updateMintAuthorization(IDCNTMintAuthorization newMintAuthorization) external onlyRole(UPDATE_MINT_AUTHORIZATION_ROLE) {
+        mintAuthorization = newMintAuthorization;
     }
 }

--- a/contracts/DCNTToken.sol
+++ b/contracts/DCNTToken.sol
@@ -33,7 +33,8 @@ contract DCNTToken is ERC20Votes, AccessControl {
     }
 
     /// @notice holders can burn their own tokens
-    function burn(uint256 amount) external {
+    /// @dev only accounts with `MINT_ROLE` (the DAO) are authorized to burn their tokens
+    function burn(uint256 amount) external onlyRole(MINT_ROLE) {
         _burn(msg.sender, amount);
     }
 

--- a/contracts/DCNTToken.sol
+++ b/contracts/DCNTToken.sol
@@ -12,7 +12,7 @@ contract DCNTToken is ERC20Votes, AccessControl {
     IDCNTMintAuthorization public mintAuthorization;
     bytes32 public constant MINT_ROLE = keccak256("MINT_ROLE");
     bytes32 public constant UPDATE_MINT_AUTHORIZATION_ROLE = keccak256("UPDATE_MINT_AUTHORIZATION_ROLE");
-    error MintAuthorization();
+    error UnauthorizedMint();
 
     constructor(uint256 _supply, address _owner, IDCNTMintAuthorization _mintAuthorization) ERC20("Decent", "DCNT") ERC20Permit("Decent") {
         _grantRole(MINT_ROLE, _owner);
@@ -27,7 +27,7 @@ contract DCNTToken is ERC20Votes, AccessControl {
     /// @dev only accounts with `MINT_ROLE` (the DAO) are authorized to mint more tokens
     function mint(address dest, uint256 amount) external onlyRole(MINT_ROLE) {
         if (!mintAuthorization.authorizeMint(dest, amount)) {
-            revert MintAuthorization();
+            revert UnauthorizedMint();
         }
         _mint(dest, amount);
     }

--- a/contracts/DCNTToken.sol
+++ b/contracts/DCNTToken.sol
@@ -2,27 +2,28 @@
 pragma solidity ^0.8.19;
 
 import { ERC20, ERC20Votes, ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";
 
 // @todo handle initial minting correctly. Can it be done inside the constructor?
 
 /// @notice the dcnt token
-contract DCNTToken is ERC20Votes, Ownable {
-    /// @param _supply amount of tokens to mint at Token Generation Event
+contract DCNTToken is ERC20Votes, AccessControl {
+    bytes32 public constant MINT_ROLE = keccak256("MINT_ROLE");
+
     constructor(uint256 _supply, address _owner) ERC20("Decent", "DCNT") ERC20Permit("Decent") {
+        _grantRole(MINT_ROLE, _owner);
         _mint(msg.sender, _supply);
-        _transferOwnership(_owner);
     }
 
-    /// @notice public mint function to be used for minting new tokens
+    /// @notice public function to be used for minting new tokens
     /// @param dest address to assign newly minted tokens to
     /// @param amount amount of tokens to mint
-    /// @dev only the `owner` is authorized to mint more tokens
-    function mint(address dest, uint256 amount) external onlyOwner {
+    /// @dev only accounts with `MINT_ROLE` (the DAO) are authorized to mint more tokens
+    function mint(address dest, uint256 amount) external onlyRole(MINT_ROLE) {
         _mint(dest, amount);
     }
 
-    /// @dev holders can burn their own tokens
+    /// @notice holders can burn their own tokens
     function burn(uint256 amount) external {
         _burn(msg.sender, amount);
     }

--- a/contracts/mint/AnnualCappedInflation.sol
+++ b/contracts/mint/AnnualCappedInflation.sol
@@ -1,0 +1,48 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.19;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { IDCNTMintAuthorization, IERC20 } from "./IDCNTMintAuthorization.sol";
+
+/// @notice an implementation of IDCNTMintAuthorization that limits mint requests to a capped annual inflation
+contract AnnualCappedInflation is Ownable, IDCNTMintAuthorization {
+    IERC20 public token;
+    uint128 public nextMint; // Timestamp
+    uint32 public constant MINIMUM_MINT_INTERVAL = 365 days;
+    uint8 public constant MINT_CAP_BPS = 200; // 2%
+
+    error MintExceedsMaximum();
+    error MintTooSoon();
+
+    constructor(IERC20 _token, uint128 _nextMint, address _owner) {
+        token = _token;
+        nextMint = _nextMint;
+        _transferOwnership(_owner);
+    }
+
+    /// @notice mint can be called at most once every 365 days, and with an amount no more than 2% of the current supply
+    /// @param amount amount of tokens to mint
+    function canMint(address, uint256 amount) public view returns (bool) {
+        if (amount > (token.totalSupply() * MINT_CAP_BPS) / 10000) {
+            revert MintExceedsMaximum();
+        }
+
+        if (block.timestamp < nextMint) {
+            revert MintTooSoon();
+        }
+
+        return true;
+    }
+
+    /// @notice mint can be called at most once every 365 days, and with an amount no more than 2% of the current supply
+    /// @param destination address where new tokens will be minted to
+    /// @param amount amount of tokens to mint
+    function authorizeMint(address destination, uint256 amount) external onlyOwner returns (bool) {
+        if (!canMint(destination, amount)) {
+            return false;
+        }
+
+        nextMint = uint128(block.timestamp + MINIMUM_MINT_INTERVAL);
+        return true;
+    }
+}

--- a/contracts/mint/IDCNTMintAuthorization.sol
+++ b/contracts/mint/IDCNTMintAuthorization.sol
@@ -1,0 +1,13 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.19;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @notice interface that all potential mint authorization contracts must conform to
+interface IDCNTMintAuthorization {
+    /// @notice function to confirm if a given mint action is authorized or not
+    /// @param destination address of the recipient of the new tokens
+    /// @param amount amount of tokens being requested
+    /// @return bool indicating whether or not the request is authorized or not
+    function authorizeMint(address destination, uint256 amount) external returns (bool);
+}

--- a/contracts/mint/NoMint.sol
+++ b/contracts/mint/NoMint.sol
@@ -1,0 +1,13 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.19;
+
+import { IDCNTMintAuthorization, IERC20 } from "./IDCNTMintAuthorization.sol";
+
+/// @notice an implementation of IDCNTMintAuthorization that allows all mint requests
+contract NoMint is IDCNTMintAuthorization {
+    
+    /// @notice simply returns true, indicating that the mint request is authorized
+    function authorizeMint(address, uint256) external pure returns (bool) {
+        return false;
+    }
+}

--- a/contracts/mint/UnlimitedMint.sol
+++ b/contracts/mint/UnlimitedMint.sol
@@ -1,0 +1,13 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.19;
+
+import { IDCNTMintAuthorization, IERC20 } from "./IDCNTMintAuthorization.sol";
+
+/// @notice an implementation of IDCNTMintAuthorization that allows all mint requests
+contract UnlimitedMint is IDCNTMintAuthorization {
+    
+    /// @notice simply returns true, indicating that the mint request is authorized
+    function authorizeMint(address, uint256) external pure returns (bool) {
+        return true;
+    }
+}

--- a/test/DCNTToken.test.ts
+++ b/test/DCNTToken.test.ts
@@ -42,7 +42,7 @@ describe("DCNTToken", async function () {
     });
 
     describe("Burning tokens", function () {
-      it("Should allow users to burn their tokens", async function () {
+      it("Should allow the MINT_ROLE to burn their own tokens", async function () {
         const totalSupply = await dcnt.totalSupply();
         const burnWhole = 500_000_000;
         const burnTotal = ethers.utils.parseEther(burnWhole.toString());
@@ -52,6 +52,13 @@ describe("DCNTToken", async function () {
         expect(await dcnt.balanceOf(owner.address)).to.eq(
           totalSupply.sub(burnTotal)
         );
+      });
+
+      it("Should not allow non-MINT_ROLE to burn their own tokens", async function () {
+        const mintRole = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MINT_ROLE'));
+        const burnWhole = 1;
+        const burnTotal = ethers.utils.parseEther(burnWhole.toString());
+        await expect(dcnt.connect(nonOwner).burn(burnTotal)).to.be.revertedWith(`AccessControl: account ${nonOwner.address.toLowerCase()} is missing role ${mintRole}`);
       });
     });
 

--- a/test/DCNTToken.test.ts
+++ b/test/DCNTToken.test.ts
@@ -57,21 +57,10 @@ describe("DCNTToken", async function () {
     });
 
     describe("Minting more tokens", function () {
-      let originalTotalSupply: BigNumber,
-        minimumMintInterval: number,
-        mintCapBPs: number,
-        nextMint: BigNumber;
+      let originalTotalSupply: BigNumber;
 
       beforeEach(async function () {
-        [originalTotalSupply, minimumMintInterval, mintCapBPs, nextMint] =
-          await Promise.all([
-            dcnt.totalSupply(),
-            dcnt.MINIMUM_MINT_INTERVAL(),
-            dcnt.MINT_CAP_BPS(),
-            dcnt.nextMint(),
-          ]);
-
-        await time.increaseTo(nextMint.toNumber());
+        originalTotalSupply = await dcnt.totalSupply();
       });
 
       describe("Depending on the caller address", function () {
@@ -92,60 +81,6 @@ describe("DCNTToken", async function () {
           await expect(
             dcnt.connect(nonOwner).mint(owner.address, oneWei)
           ).to.be.revertedWith("Ownable: caller is not the owner");
-        });
-      });
-
-      describe("Depending on the amount", function () {
-        let maxToMint: BigNumber;
-
-        beforeEach(async function () {
-          // calculate the max amount of tokens that can be minted
-          maxToMint = originalTotalSupply.mul(mintCapBPs).div(10000);
-        });
-
-        describe("Max mint amount", function () {
-          it("Should allow the owner to mint more tokens", async function () {
-            await dcnt.mint(owner.address, maxToMint);
-            expect(await dcnt.totalSupply()).to.eq(
-              originalTotalSupply.add(maxToMint)
-            );
-          });
-        });
-
-        describe("Over max mint amount", function () {
-          let overMaxToMint: BigNumber;
-
-          beforeEach(function () {
-            overMaxToMint = maxToMint.add(1);
-          });
-
-          it("Should not allow the owner to mint more tokens", async function () {
-            await expect(
-              dcnt.mint(owner.address, overMaxToMint)
-            ).to.be.revertedWith("MintExceedsMaximum()");
-          });
-        });
-      });
-
-      describe("Depending on the time", function () {
-        beforeEach(async function () {
-          // dummy mint to set the timeout interval
-          await dcnt.mint(owner.address, 0);
-        });
-
-        it("Should not allow the owner to mint after having just minted", async function () {
-          await expect(dcnt.mint(owner.address, 1)).to.be.revertedWith(
-            "MintTooSoon()"
-          );
-        });
-
-        it("Should allow the owner to mint after the minimum mint interval", async function () {
-          await time.increase(minimumMintInterval);
-          const toMint = 1;
-          await dcnt.mint(owner.address, toMint);
-          expect(await dcnt.totalSupply()).to.eq(
-            originalTotalSupply.add(toMint)
-          );
         });
       });
     });

--- a/test/DCNTToken.test.ts
+++ b/test/DCNTToken.test.ts
@@ -115,6 +115,25 @@ describe("DCNTToken", async function () {
         ).to.be.revertedWith(`AccessControl: account ${nonOwner.address.toLowerCase()} is missing role ${updateMintAuthorizationRole}`);
         expect(await dcnt.mintAuthorization()).to.eq(originalMintAuthorizationAddress);
       });
-    })
+    });
+
+    describe("Revoking roles and testing behavior", function () {
+      describe("Revoking the MINT_ROLE", function () {
+        it("Doesn't allow any more minting", async function () {
+          const mintRole = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MINT_ROLE'));
+          await dcnt.renounceRole(mintRole, owner.address);
+          await expect(dcnt.mint(owner.address, 1)).to.be.revertedWith(`AccessControl: account ${owner.address.toLowerCase()} is missing role ${mintRole}`);
+        });
+      });
+
+      describe("Revoking the UPDATE_MINT_AUTHORIZATION_ROLE", function () {
+        it("Doesn't allow updating the mint authorization contract", async function () {
+          const updateMintAuthorizationRole = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('UPDATE_MINT_AUTHORIZATION_ROLE'));
+          await dcnt.renounceRole(updateMintAuthorizationRole, owner.address);
+          const newInstance = await new UnlimitedMint__factory(owner).deploy();
+          await expect(dcnt.updateMintAuthorization(newInstance.address)).to.be.revertedWith(`AccessControl: account ${owner.address.toLowerCase()} is missing role ${updateMintAuthorizationRole}`);
+        });
+      });
+    });
   });
 });

--- a/test/DCNTToken.test.ts
+++ b/test/DCNTToken.test.ts
@@ -24,7 +24,7 @@ describe("DCNTToken", async function () {
   });
 
   describe("Token features", function () {
-    describe("Minting the correct amount of tokens", function () {
+    describe("Minting the correct amount of tokens at deployment", function () {
       let totalSupply: BigNumber;
 
       beforeEach(async function () {
@@ -78,9 +78,11 @@ describe("DCNTToken", async function () {
         });
 
         it("Should not allow non-owner to mint 1 wei", async function () {
+          const mintRole = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MINT_ROLE'));
+
           await expect(
             dcnt.connect(nonOwner).mint(owner.address, oneWei)
-          ).to.be.revertedWith("Ownable: caller is not the owner");
+          ).to.be.revertedWith(`AccessControl: account ${nonOwner.address.toLowerCase()} is missing role ${mintRole}`);
         });
       });
     });

--- a/test/DCNTToken.test.ts
+++ b/test/DCNTToken.test.ts
@@ -85,5 +85,28 @@ describe("DCNTToken", async function () {
         });
       });
     });
+
+    describe("Updating the MintAuthorization contract", function () {
+      let newInstance: UnlimitedMint;
+
+      beforeEach(async function () {
+        newInstance = await new UnlimitedMint__factory(owner).deploy();
+      });
+
+      it("Should allow owner to update to a new instance", async function () {
+        await dcnt.updateMintAuthorization(newInstance.address);
+        expect(await dcnt.mintAuthorization()).to.eq(newInstance.address);
+      });
+
+      it("Should not allow non-owner to update to a new instance", async function () {
+        const updateMintAuthorizationRole = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('UPDATE_MINT_AUTHORIZATION_ROLE'));
+        const originalMintAuthorizationAddress = await dcnt.mintAuthorization();
+
+        await expect(
+          dcnt.connect(nonOwner).updateMintAuthorization(newInstance.address)
+        ).to.be.revertedWith(`AccessControl: account ${nonOwner.address.toLowerCase()} is missing role ${updateMintAuthorizationRole}`);
+        expect(await dcnt.mintAuthorization()).to.eq(originalMintAuthorizationAddress);
+      });
+    })
   });
 });

--- a/test/DCNTToken.test.ts
+++ b/test/DCNTToken.test.ts
@@ -2,9 +2,7 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
 import { BigNumber } from "ethers";
 import { ethers } from "hardhat";
-import { DCNTToken } from "../typechain";
-
-import time from "./time";
+import { DCNTToken, DCNTToken__factory, UnlimitedMint, UnlimitedMint__factory } from "../typechain";
 
 describe("DCNTToken", async function () {
   let owner: SignerWithAddress;
@@ -17,10 +15,11 @@ describe("DCNTToken", async function () {
   beforeEach(async function () {
     [owner, nonOwner] = await ethers.getSigners();
 
-    // Deploy token contract
-    const _DCNTToken = await ethers.getContractFactory("DCNTToken");
-    dcnt = await _DCNTToken.deploy(mintTotal, owner.address);
-    await dcnt.deployed();
+    dcnt = await new DCNTToken__factory(owner).deploy(
+      mintTotal,
+      owner.address,
+      (await new UnlimitedMint__factory(owner).deploy()).address
+    );
   });
 
   describe("Token features", function () {

--- a/test/DCNTToken.test.ts
+++ b/test/DCNTToken.test.ts
@@ -2,7 +2,7 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
 import { BigNumber } from "ethers";
 import { ethers } from "hardhat";
-import { DCNTToken, DCNTToken__factory, UnlimitedMint, UnlimitedMint__factory } from "../typechain";
+import { DCNTToken, DCNTToken__factory, UnlimitedMint, UnlimitedMint__factory, NoMint__factory } from "../typechain";
 
 describe("DCNTToken", async function () {
   let owner: SignerWithAddress;
@@ -82,6 +82,14 @@ describe("DCNTToken", async function () {
           await expect(
             dcnt.connect(nonOwner).mint(owner.address, oneWei)
           ).to.be.revertedWith(`AccessControl: account ${nonOwner.address.toLowerCase()} is missing role ${mintRole}`);
+        });
+      });
+
+      describe("When not authorized", function () {
+        it("Throws an error", async function () {
+          let noMint = await new NoMint__factory(owner).deploy();
+          await dcnt.updateMintAuthorization(noMint.address);
+          await expect(dcnt.mint(owner.address, 1)).to.be.revertedWith("UnauthorizedMint()");
         });
       });
     });

--- a/test/LockRelease.test.ts
+++ b/test/LockRelease.test.ts
@@ -7,6 +7,7 @@ import {
   DCNTToken__factory,
   LockRelease,
   LockRelease__factory,
+  UnlimitedMint__factory,
 } from "../typechain";
 
 import time from "./time";
@@ -32,7 +33,11 @@ describe("LockRelease", async function () {
     duration = 100;
 
     // Deploy DCNT token
-    dcnt = await new DCNTToken__factory(deployer).deploy(1000, owner.address);
+    dcnt = await new DCNTToken__factory(deployer).deploy(
+      1000,
+      owner.address,
+      (await new UnlimitedMint__factory(deployer).deploy()).address
+    );
   });
 
   describe("LockRelease Deployment", function () {

--- a/test/mint/AnnualCappedInflation.test.ts
+++ b/test/mint/AnnualCappedInflation.test.ts
@@ -1,0 +1,138 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { BigNumber } from "ethers";
+import { AnnualCappedInflation__factory, DCNTToken__factory, UnlimitedMint__factory } from "../../typechain";
+
+import time from "../time";
+import { loadFixture } from "ethereum-waffle";
+
+describe("AnnualCappedInflation", async function () {
+  async function deployAnnualCappedInflation() {
+    const [deployer, dao] = await ethers.getSigners();
+    const dcnt = await new DCNTToken__factory(deployer).deploy(
+      ethers.utils.parseEther("1000"),
+      dao.address,
+      (await new UnlimitedMint__factory(deployer).deploy()).address
+    );
+    const currentTime = await time.latest()
+    const annualCappedInflation = await new AnnualCappedInflation__factory(deployer).deploy(dcnt.address, currentTime + 100, dao.address);
+    await dcnt.connect(dao).updateMintAuthorization(annualCappedInflation.address);
+
+    const [minimumMintInterval, mintCapBPs] = await Promise.all([annualCappedInflation.MINIMUM_MINT_INTERVAL(), annualCappedInflation.MINT_CAP_BPS()]);
+
+    return { annualCappedInflation, dcnt, dao, minimumMintInterval, mintCapBPs };
+  };
+
+  describe("Getting authorization to mint more tokens", function () {
+    let originalTotalSupply: BigNumber;
+    let nextMint: BigNumber;
+
+    beforeEach(async function () {
+      const { annualCappedInflation, dcnt } = await loadFixture(deployAnnualCappedInflation);
+
+      [originalTotalSupply, nextMint] =
+        await Promise.all([
+          dcnt.totalSupply(),
+          annualCappedInflation.nextMint(),
+        ]);
+
+      const currentTime = await time.latest();
+
+      if (nextMint.toNumber() > currentTime) {
+        await time.increaseTo(nextMint.toNumber());
+      }
+    });
+
+    describe("Depending on the amount", function () {
+      let maxToMint: BigNumber;
+
+      beforeEach(async function () {
+        const { mintCapBPs } = await loadFixture(deployAnnualCappedInflation);
+
+        // calculate the max amount of tokens that can be minted
+        maxToMint = originalTotalSupply.mul(mintCapBPs).div(10000);
+      });
+
+      describe("Checking the view function", async function () {
+        it("Should authorize minting max amount", async function () {
+          const { annualCappedInflation } = await loadFixture(deployAnnualCappedInflation);
+          const authorized = await annualCappedInflation.callStatic.canMint(ethers.constants.AddressZero, maxToMint);
+          expect(authorized).to.be.true;
+        });
+  
+        it("Should not authorize minting above max amount", async function () {
+          const { annualCappedInflation } = await loadFixture(deployAnnualCappedInflation);
+          let overMaxToMint = maxToMint.add(1);
+          await expect(annualCappedInflation.callStatic.canMint(ethers.constants.AddressZero, overMaxToMint)).to.be.revertedWith("MintExceedsMaximum()");
+        });
+      });
+
+      describe("Calling the authorization function", async function () {
+        it("Should authorize minting max amount", async function () {
+          const { annualCappedInflation, minimumMintInterval, dao } = await loadFixture(deployAnnualCappedInflation);
+          await annualCappedInflation.connect(dao).authorizeMint(ethers.constants.AddressZero, maxToMint);
+          const currentTime = await time.latest();
+          const nextMintFromContract = await annualCappedInflation.nextMint();
+          expect(nextMintFromContract).to.eq(minimumMintInterval + currentTime);
+        });
+  
+        it("Should not authorize minting above max amount", async function () {
+          const { annualCappedInflation, dao } = await loadFixture(deployAnnualCappedInflation);
+          let overMaxToMint = maxToMint.add(1);
+          const originalNextMintFromContract = await annualCappedInflation.nextMint();
+          await expect(annualCappedInflation.connect(dao).authorizeMint(ethers.constants.AddressZero, overMaxToMint)).to.be.revertedWith("MintExceedsMaximum()");
+          const nextMintFromContract = await annualCappedInflation.nextMint();
+          expect(nextMintFromContract).to.eq(originalNextMintFromContract);
+        });
+      });
+    });
+
+    describe("Depending on the time", function () {
+      beforeEach(async function () {
+        const { annualCappedInflation, dao } = await loadFixture(deployAnnualCappedInflation);
+
+        // dummy mint to set the timeout interval
+        await annualCappedInflation.connect(dao).authorizeMint(dao.address, 0);
+      });
+
+      describe("Checking the view function", async function () {
+        it("Should not authorize minting after having just minted", async function () {
+          const { annualCappedInflation } = await loadFixture(deployAnnualCappedInflation);
+          await expect(annualCappedInflation.callStatic.canMint(ethers.constants.AddressZero, 1)).to.be.revertedWith("MintTooSoon()");
+        });
+  
+        it("Should authorize minting after the minimum mint interval", async function () {
+          const { annualCappedInflation, minimumMintInterval } = await loadFixture(deployAnnualCappedInflation);
+          await time.increase(minimumMintInterval);
+          const toMint = 1;
+          const authorized = await annualCappedInflation.callStatic.canMint(ethers.constants.AddressZero, toMint);
+          expect(authorized).to.be.true
+        });
+      });
+
+      describe("Calling the authorization function", async function () {
+        it("Should not authorize minting after having just minted", async function () {
+          const { annualCappedInflation, dao } = await loadFixture(deployAnnualCappedInflation);
+          await expect(annualCappedInflation.connect(dao).authorizeMint(ethers.constants.AddressZero, 1)).to.be.revertedWith("MintTooSoon()");
+        });
+  
+        it("Should authorize minting after the minimum mint interval", async function () {
+          const { annualCappedInflation, minimumMintInterval, dao } = await loadFixture(deployAnnualCappedInflation);
+          await time.increase(minimumMintInterval);
+          const toMint = 1;
+          await annualCappedInflation.connect(dao).authorizeMint(ethers.constants.AddressZero, toMint);
+          const currentTime = await time.latest();
+          const nextMintFromContract = await annualCappedInflation.nextMint();
+          expect(nextMintFromContract).to.eq(minimumMintInterval + currentTime);
+        });
+      });
+    });
+
+    describe("Can only happen from the owner", function () {
+      it("Fails if authorization is attemped by non-owner", async function () {
+        const { annualCappedInflation, minimumMintInterval, dao } = await loadFixture(deployAnnualCappedInflation);
+        await expect(annualCappedInflation.authorizeMint(ethers.constants.AddressZero, 0)).to.be.revertedWith("Ownable: caller is not the owner");
+      });
+    });
+  });
+});

--- a/test/mint/NoMint.test.ts
+++ b/test/mint/NoMint.test.ts
@@ -1,0 +1,17 @@
+import { loadFixture } from "ethereum-waffle";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { NoMint__factory } from "../../typechain";
+
+describe("NoMint", async function () {
+  async function deployNoMint() {
+    const [owner] = await ethers.getSigners();
+    const noMint = await new NoMint__factory(owner).deploy();
+    return { noMint };
+  };
+
+  it("returns false", async function () {
+    const { noMint } = await loadFixture(deployNoMint);
+    expect(await noMint.authorizeMint(ethers.constants.AddressZero, 0)).to.be.false;
+  });
+});

--- a/test/mint/UnlimitedMint.test.ts
+++ b/test/mint/UnlimitedMint.test.ts
@@ -1,0 +1,17 @@
+import { loadFixture } from "ethereum-waffle";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { UnlimitedMint__factory } from "../../typechain";
+
+describe("UnlimitedMint", async function () {
+  async function deployUnlimitedMint() {
+    const [owner] = await ethers.getSigners();
+    const unlimitedMint = await new UnlimitedMint__factory(owner).deploy();
+    return { unlimitedMint };
+  };
+
+  it("returns true", async function () {
+    const { unlimitedMint } = await loadFixture(deployUnlimitedMint);
+    expect(await unlimitedMint.authorizeMint(ethers.constants.AddressZero, 0)).to.be.true;
+  });
+});


### PR DESCRIPTION
This PR introduces logic which allows the ability to _upgrade_ the authorization logic associated with minting new tokens.

# Context

In the absence of a clear tokenomic strategy for DCNT (especially in the absence of a clear business and strategic direction for Decent), I believe it is premature to hardcode any minting or burning constraints into the token contract at launch.

## Is this risky?

In the worst case, a governance attacker would amass enough tokens to push through a proposal which does one or more of the following:

- mints and dumps a large quantity of tokens, crashing the DCNT price
- steals assets from Decent's treasury

At launch, DCNT will be owned by a totally known set of individuals and investors, and these tokens will be non-transferable for one year. For one year, the only way for DCNT tokens to get out of the walled garden would be through a deliberate and explicit proposal, from a known entity, to release more tokens from the treasury, or to mint them.

For this reason, I place the risk of a _governance attack_ from an anon entity as virtually nonexistent for up to one year after launch.

# Implementation details

An interface has been created which requires the implementation of a function (`authorizeMint`) that should contain logic that returns `true` or `false`, indicating whether or not the mint request is authorized or not.

The DCNT token contract:

- Holds a pointer to a contract which implements this interface.
- Uses the `authorizeMint` function of this interface in its own `mint` function, to determine if the mint should happen or not.
  - The DAO address is still the only address that can call `mint` on the DCNT token contract. This authentication has been kept on the DCNT contract.
- Allows the DAO to replace the pointer to the `IDCNTMintAuthorization` implementation with a new implementation.
- Allows the DAO to revoke its ability to (independently):
  - Make any more replacements of that `IDCNTMintAuthorization` implementation.
  - Call the `mint` function.

The first implementation of `IDCNTMintAuthorization` is a contract called `UnlimitedMint`, which simply returns `true` for any call to `authorizeMint`. As stated in the Context above, I believe this is a flexible and safe decision at launch.

As always, to best understand the changes in this PR, please review the commits one by one, in order.

# End State

The code is designed in such a way that once Decent _does_ figure out what tokenomics work best for our organization, and what those minting constraints look like, we can then stamp that logic into the blockchain and revoke the ability to change them again.

We have a year to figure this out before the risk of governance attacks increases.