### PR TITLE
Remove ability for ERC20-level token burning

### DIFF
--- a/contracts/DCNTToken.sol
+++ b/contracts/DCNTToken.sol
@@ -39,9 +39,4 @@ contract DCNTToken is ERC20Votes, Ownable {
         nextMint = uint128(block.timestamp + MINIMUM_MINT_INTERVAL);
         _mint(dest, amount);
     }
-
-    /// @dev holders can burn their own tokens
-    function burn(uint256 amount) external {
-        _burn(msg.sender, amount);
-    }
 }

--- a/test/DCNTToken.test.ts
+++ b/test/DCNTToken.test.ts
@@ -42,20 +42,6 @@ describe("DCNTToken", async function () {
       });
     });
 
-    describe("Burning tokens", function () {
-      it("Should allow users to burn their tokens", async function () {
-        const totalSupply = await dcnt.totalSupply();
-        const burnWhole = 500_000_000;
-        const burnTotal = ethers.utils.parseEther(burnWhole.toString());
-        await dcnt.connect(owner).burn(burnTotal);
-
-        expect(await dcnt.totalSupply()).to.eq(totalSupply.sub(burnTotal));
-        expect(await dcnt.balanceOf(owner.address)).to.eq(
-          totalSupply.sub(burnTotal)
-        );
-      });
-    });
-
     describe("Minting more tokens", function () {
       let originalTotalSupply: BigNumber,
         minimumMintInterval: number,


### PR DESCRIPTION
In retrospect I just don't like this, and don't want to give the ability (to _everyone_) to be able manipulate the "max total supply" property on Etherscan.